### PR TITLE
Read-requests sent encoded

### DIFF
--- a/common/common_config.go
+++ b/common/common_config.go
@@ -21,7 +21,7 @@ type CommonConfig struct {
 }
 
 func (cc *CommonConfig) WindowSize() int {
-	return int(float32(int(cc.NumBuckets) * cc.BucketDepth) * cc.MaxLoadFactor)
+	return int(float32(int(cc.NumBuckets)*cc.BucketDepth) * cc.MaxLoadFactor)
 }
 
 // Load configuration from a JSON file. returns the config on success or nil if

--- a/common/follower_protocol.go
+++ b/common/follower_protocol.go
@@ -4,7 +4,7 @@ type BatchReadRequest struct {
 	Args       []PirArgs // Set of Read requests
 	SeqNoRange Range
 	RandSeed   int64
-	ReplyChan chan *BatchReadReply
+	ReplyChan  chan *BatchReadReply
 }
 
 type BatchReadReply struct {

--- a/common/follower_rpc.go
+++ b/common/follower_rpc.go
@@ -21,7 +21,7 @@ func NewFollowerRpc(name string, config *TrustDomainConfig) *FollowerRpc {
 	f.name = name
 	f.config = config
 	f.client = nil
-	if f.config.IsDistributed() {
+	if f.config.IsDistributed {
 		f.methodPrefix = "Frontend"
 	} else {
 		f.methodPrefix = "Centralized"

--- a/common/leader_interface.go
+++ b/common/leader_interface.go
@@ -4,6 +4,6 @@ type LeaderInterface interface {
 	GetName() string
 	Ping(args *PingArgs, reply *PingReply) error
 	Write(args *WriteArgs, reply *WriteReply) error
-	Read(args *ReadArgs, reply *ReadReply) error
+	Read(args *EncodedReadArgs, reply *ReadReply) error
 	GetUpdates(args *GetUpdatesArgs, reply *GetUpdatesReply) error
 }

--- a/common/leader_protocol.go
+++ b/common/leader_protocol.go
@@ -26,7 +26,7 @@ type WriteArgs struct {
 	InterestVector []byte
 	//Internal
 	GlobalSeqNo uint64
-	ReplyChan chan *WriteReply
+	ReplyChan   chan *WriteReply
 }
 
 type WriteReply struct {
@@ -40,7 +40,13 @@ type PirArgs struct {
 }
 
 type ReadArgs struct {
-	ForTd []PirArgs // Set of args for each trust domain
+	TD []PirArgs
+}
+
+type EncodedReadArgs struct {
+	ClientKey [32]byte
+	Nonce     [24]byte
+	PirArgs   [][]byte //An encrypted PirArgs for each trust domain
 }
 
 type ReadReply struct {

--- a/common/leader_rpc.go
+++ b/common/leader_rpc.go
@@ -21,7 +21,7 @@ func NewLeaderRpc(name string, config *TrustDomainConfig) *LeaderRpc {
 	l.name = name
 	l.config = config
 	l.client = nil
-	if l.config.IsDistributed() {
+	if l.config.IsDistributed {
 		l.methodPrefix = "Frontend"
 	} else {
 		l.methodPrefix = "Centralized"
@@ -76,7 +76,7 @@ func (l *LeaderRpc) Write(args *WriteArgs, reply *WriteReply) error {
 	return err
 }
 
-func (l *LeaderRpc) Read(args *ReadArgs, reply *ReadReply) error {
+func (l *LeaderRpc) Read(args *EncodedReadArgs, reply *ReadReply) error {
 	//l.log.Printf("Read: enter\n")
 	err := l.Call(l.methodPrefix+".Read", args, reply)
 	return err

--- a/common/readargs.go
+++ b/common/readargs.go
@@ -1,0 +1,58 @@
+package common
+
+/**
+ * Underlying Algorithm for the client to encrypt read args to the different
+ * servers, and servers to decrypt and read the encoded args.
+ */
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/gob"
+	"errors"
+	"golang.org/x/crypto/nacl/box"
+)
+
+func (r *ReadArgs) Encode(trustDomains []*TrustDomainConfig) (out EncodedReadArgs, err error) {
+	pubKey, priKey, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		return
+	}
+	nonce := make([]byte, 24)
+	_, err = rand.Read(nonce)
+	if err != nil {
+		return
+	}
+
+	// Allocate memory
+	copy(out.ClientKey[:], pubKey[:])
+	copy(out.Nonce[:], nonce)
+
+	out.PirArgs = make([][]byte, len(trustDomains))
+
+	var msg bytes.Buffer
+	enc := gob.NewEncoder(&msg)
+	for i := 0; i < len(trustDomains); i++ {
+		err = enc.Encode(r.TD[i])
+		if err != nil {
+			return
+		}
+		msgBytes := msg.Bytes()
+		out.PirArgs[i] = make([]byte, 0, len(msgBytes)+box.Overhead)
+		ret := box.Seal(out.PirArgs[i], msgBytes, &out.Nonce, &trustDomains[i].PublicKey, priKey)
+		out.PirArgs[i] = ret
+	}
+	return
+}
+
+func (r *EncodedReadArgs) Decode(id int, trustDomain *TrustDomainConfig) (out PirArgs, err error) {
+	if len(r.PirArgs[id]) < box.Overhead {
+		err = errors.New("Attempted Decoding of invalid Trust Domain")
+		return
+	}
+	msg := make([]byte, 0, len(r.PirArgs[id])-box.Overhead)
+	decrypted, _ := box.Open(msg, r.PirArgs[id], &r.Nonce, &r.ClientKey, &trustDomain.privateKey)
+	dec := gob.NewDecoder(bytes.NewBuffer(decrypted))
+	err = dec.Decode(&out)
+	return
+}

--- a/common/readargs_test.go
+++ b/common/readargs_test.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"bytes"
+	"crypto/rand"
+	"golang.org/x/crypto/nacl/box"
+	"testing"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	msg := &ReadArgs{}
+	msg.TD = make([]PirArgs, 3)
+	config := make([]*TrustDomainConfig, 3)
+
+	for i := 0; i < 3; i++ {
+		config[i] = &TrustDomainConfig{}
+		msg.TD[i].RequestVector = make([]byte, 32)
+		msg.TD[i].PadSeed = make([]byte, 4)
+		serverPub, serverPri, _ := box.GenerateKey(rand.Reader)
+		copy(config[i].PublicKey[:], serverPub[:])
+		copy(config[i].privateKey[:], serverPri[:])
+	}
+
+	encodedArgs, err := msg.Encode(config)
+	if err != nil || len(encodedArgs.PirArgs) != 3 {
+		t.Fatal(err)
+	}
+
+	//for each server...
+	for i := 0; i < 3; i++ {
+		pir, err := encodedArgs.Decode(i, config[i])
+		if err != nil {
+			t.Fatalf("Error Decoding TD[%d] len(%d): %v\n", i, len(encodedArgs.PirArgs[i]), err)
+		}
+		if bytes.Compare(pir.PadSeed, msg.TD[i].PadSeed) != 0 ||
+			bytes.Compare(pir.RequestVector, msg.TD[i].RequestVector) != 0 {
+			t.Fatalf("Decryption not equal.")
+		}
+	}
+}

--- a/common/trustdomain_config.go
+++ b/common/trustdomain_config.go
@@ -1,35 +1,90 @@
 package common
 
+import (
+	"crypto/rand"
+	"encoding/json"
+	"golang.org/x/crypto/nacl/box"
+)
+
 type TrustDomainConfig struct {
-	name          string
-	address       string
-	isValid       bool
-	isDistributed bool
+	Name          string
+	Address       string
+	IsValid       bool
+	IsDistributed bool
+	PublicKey     [32]byte
+	privateKey    [32]byte
+}
+
+type PrivateTrustDomainConfig struct {
+	*TrustDomainConfig
+	PrivateKey [32]byte
 }
 
 func NewTrustDomainConfig(name string, address string, isValid bool, isDistributed bool) *TrustDomainConfig {
 	td := &TrustDomainConfig{}
-	td.name = name
-	td.address = address
-	td.isValid = isValid
-	td.isDistributed = isDistributed
+	td.Name = name
+	td.Address = address
+	td.IsValid = isValid
+	td.IsDistributed = isDistributed
+	pubKey, priKey, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		td.IsValid = false
+		return td
+	}
+	copy(td.PublicKey[:], pubKey[:])
+	copy(td.privateKey[:], priKey[:])
 	return td
 }
 
+func (t *TrustDomainConfig) UnmarshalJSON(marshaled []byte) error {
+	if len(marshaled) == 0 {
+		return nil
+	}
+	// The union type between TrustDomainCOnfig and PrivateTrustDomainConfig.
+	type Config struct {
+		PublicKey     [32]byte
+		PrivateKey    [32]byte
+		Name          string
+		Address       string
+		IsValid       bool
+		IsDistributed bool
+	}
+	var config Config
+	if err := json.Unmarshal(marshaled, &config); err != nil {
+		return err
+	}
+
+	copy(t.privateKey[:], config.PrivateKey[:])
+	copy(t.PublicKey[:], config.PublicKey[:])
+	t.Name = config.Name
+	t.Address = config.Address
+	t.IsValid = config.IsValid
+	t.IsDistributed = config.IsDistributed
+
+	return nil
+}
+
+/**
+ * Expose the Private key of a trust domain config so that it can be saved
+ * and restored.
+ */
+func (td *TrustDomainConfig) Private() *PrivateTrustDomainConfig {
+	PTDC := new(PrivateTrustDomainConfig)
+	PTDC.TrustDomainConfig = td
+	copy(PTDC.PrivateKey[:], td.privateKey[:])
+	return PTDC
+}
+
 func (td *TrustDomainConfig) GetName() (string, bool) {
-	if td.isValid == false {
+	if td.IsValid == false {
 		return "", false
 	}
-	return td.name, td.isValid
+	return td.Name, td.IsValid
 }
 
 func (td *TrustDomainConfig) GetAddress() (string, bool) {
-	if td.isValid == false {
+	if td.IsValid == false {
 		return "", false
 	}
-	return td.address, td.isValid
-}
-
-func (td *TrustDomainConfig) IsDistributed() bool {
-	return td.isDistributed
+	return td.Address, td.IsValid
 }

--- a/common/trustdomain_config_test.go
+++ b/common/trustdomain_config_test.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestTrustDomainMarshaling(t *testing.T) {
+	tdc := NewTrustDomainConfig("testing", "0.0.0.0", true, false)
+	if tdc == nil {
+		t.Fatal("Failed to make trust domain.")
+	}
+	publicBytes, err := json.Marshal(tdc)
+	if err != nil {
+		t.Fatalf("Failed to serialize Trust Domain.")
+	}
+
+	publicDomain := new(TrustDomainConfig)
+	err = publicDomain.UnmarshalJSON(publicBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(publicDomain.privateKey[:], tdc.privateKey[:]) == 0 {
+		t.Fatal("Serialization should not re-create private key")
+	}
+	if bytes.Compare(publicDomain.PublicKey[:], tdc.PublicKey[:]) != 0 {
+		t.Fatal("Serialization should re-create public key")
+	}
+
+	privatebytes, err := json.Marshal(tdc.Private())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privateDomain := new(TrustDomainConfig)
+	err = privateDomain.UnmarshalJSON(privatebytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Compare(privateDomain.privateKey[:], tdc.privateKey[:]) != 0 {
+		t.Fatal("Serialization of private() should re-create private key")
+	}
+}

--- a/libtalek/client_config.go
+++ b/libtalek/client_config.go
@@ -17,7 +17,7 @@ type ClientConfig struct {
 	ReadInterval time.Duration
 
 	// Where are the different servers?
-	TrustDomains []*common.TrustDomainConfig `json:"-"`
+	TrustDomains []*common.TrustDomainConfig
 }
 
 // Load configuration from a JSON file. returns the config on success or nil if

--- a/libtalek/client_test.go
+++ b/libtalek/client_test.go
@@ -6,68 +6,68 @@ import (
 	"github.com/privacylab/talek/common"
 	"github.com/privacylab/talek/drbg"
 	"testing"
-  "time"
+	"time"
 )
 
-type mockLeader struct{
-  ReceivedWrites chan *common.WriteArgs
+type mockLeader struct {
+	ReceivedWrites chan *common.WriteArgs
 }
+
 func (m *mockLeader) GetName() string {
-  return "Mock Leader"
+	return "Mock Leader"
 }
 func (m *mockLeader) Ping(args *common.PingArgs, reply *common.PingReply) error {
-  return nil
+	return nil
 }
 func (m *mockLeader) Write(args *common.WriteArgs, reply *common.WriteReply) error {
-  m.ReceivedWrites <- args
-  return nil
+	m.ReceivedWrites <- args
+	return nil
 }
-func (m *mockLeader) Read(args *common.ReadArgs, reply *common.ReadReply) error {
-  return nil
+func (m *mockLeader) Read(args *common.EncodedReadArgs, reply *common.ReadReply) error {
+	return nil
 }
 func (m *mockLeader) GetUpdates(args *common.GetUpdatesArgs, reply *common.GetUpdatesReply) error {
-  return nil
+	return nil
 }
 
-
 func TestWrite(t *testing.T) {
-  config := ClientConfig{
-    &common.CommonConfig{64, 4, 1024, 0.05, 0.95, 0.05},
-    time.Second,
-    time.Second,
-    []*common.TrustDomainConfig{common.NewTrustDomainConfig("TestTrustDomain", "127.0.0.1", true, false)},
-  }
+	config := ClientConfig{
+		&common.CommonConfig{64, 4, 1024, 0.05, 0.95, 0.05},
+		time.Second,
+		time.Second,
+		[]*common.TrustDomainConfig{common.NewTrustDomainConfig("TestTrustDomain", "127.0.0.1", true, false)},
+	}
 
-  writes := make(chan *common.WriteArgs, 1)
-  leader := mockLeader{writes}
+	writes := make(chan *common.WriteArgs, 1)
+	leader := mockLeader{writes}
 
-  c := NewClient("TestClient", config, &leader)
-  if c == nil {
-    t.Fatalf("Error creating client")
-  }
+	c := NewClient("TestClient", config, &leader)
+	if c == nil {
+		t.Fatalf("Error creating client")
+	}
 
-  handle, _ := NewTopic()
+	handle, _ := NewTopic()
 
 	// Recreate the expected buckets to make sure we're seeing
 	// the real write.
 	var seqNoBytes [24]byte
 	_ = binary.PutUvarint(seqNoBytes[:], handle.Seqno)
 	// Clone seed so they advance together.
-  seedData, _ := handle.Subscription.Seed1.MarshalBinary()
+	seedData, _ := handle.Subscription.Seed1.MarshalBinary()
 	seed := drbg.Seed{}
 	seed.UnmarshalBinary(seedData)
 	k0, k1 := seed.KeyUint128()
 	bucket := siphash.Hash(k0, k1, seqNoBytes[:]) % 64
 
-  c.Publish(handle, []byte("hello world"))
-  write1 := <- writes
-	write2 := <- writes
-  c.Kill()
+	c.Publish(handle, []byte("hello world"))
+	write1 := <-writes
+	write2 := <-writes
+	c.Kill()
 	//Due to thread race, there may be a random write made before
 	//the requested publish is queued up.
-  if write1.Bucket1 != bucket && write2.Bucket1 != bucket {
-    t.Fatalf("Didn't get expected write position.")
-  }
+	if write1.Bucket1 != bucket && write2.Bucket1 != bucket {
+		t.Fatalf("Didn't get expected write position.")
+	}
 }
 
 //TODO: test reading.

--- a/libtalek/subscription_test.go
+++ b/libtalek/subscription_test.go
@@ -28,7 +28,7 @@ func TestGeneratePoll(t *testing.T) {
 		t.Fatalf("Error creating ReadArgs: %v\n", err)
 	}
 
-	fmt.Printf("len(args0)=%v; \n", 3*(len(args0.ForTd[0].RequestVector)+len(args0.ForTd[0].PadSeed)))
+	fmt.Printf("len(args0)=%v; \n", 3*(len(args0.TD[0].RequestVector)+len(args0.TD[0].PadSeed)))
 
 	fmt.Printf("... done \n")
 }

--- a/libtalek/topic.go
+++ b/libtalek/topic.go
@@ -14,7 +14,7 @@ import (
 type Topic struct {
 
 	// For updates?
-	Id    uint64
+	Id uint64
 
 	// For authenticity
 	// TODO: this should ratchet.
@@ -44,7 +44,6 @@ func NewTopic() (t *Topic, err error) {
 	t.Subscription.Seed1 = *seed1
 	t.Subscription.Seed2 = *seed2
 	t.Subscription.drbg, err = drbg.NewHashDrbg(nil)
-
 
 	// Create shared secret
 	pub, priv, err := box.GenerateKey(rand.Reader)


### PR DESCRIPTION
This is step 1 of several in addressing #23.  These are the changes in `common`; namely that `ReadArgs` have an encoded form, and `TrustDomainConfig` now handles its requisite asymmetric key.