### PR TITLE
Periodically trigger database writes when write volume is insufficient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 benchmark/client/client
+benchmark/consistency/consistency
 benchmark/server/server
 pird/pird
+util/talekcli/talekcli
 util/talekutil/talekutil

--- a/benchmark/consistency/consistency.go
+++ b/benchmark/consistency/consistency.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/privacylab/talek/common"
+	"github.com/privacylab/talek/libtalek"
+)
+
+var configPath = flag.String("config", "../commonconfig.json", "Talek Common Configuration")
+var trustDomainPath = flag.String("trust", "../keys/leaderpublic.json,../keys/followerpublic.json", "Server keys (comma separated)")
+
+// Consistency acts as a client driver against a talek system to verify that
+// consistency guarantees are enforced. It will write into a cell, and then
+// perform a set of reads to ensure that all servers expose the same snapshot
+// of the database and are synchronized.
+func main() {
+	flag.Parse()
+
+	// Config
+	config := common.CommonConfigFromFile(*configPath)
+	domainPaths := strings.Split(*trustDomainPath, ",")
+	trustDomains := make([]*common.TrustDomainConfig, len(domainPaths))
+	for i, path := range domainPaths {
+		tdString, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Printf("Could not read %s!\n", path)
+			return
+		}
+		trustDomains[i] = new(common.TrustDomainConfig)
+		if err := json.Unmarshal(tdString, trustDomains[i]); err != nil {
+			log.Printf("Could not parse %s: %v\n", path, err)
+			return
+		}
+	}
+
+	leaderRPC := common.NewLeaderRpc("RPC", trustDomains[0])
+
+	clientConfig := libtalek.ClientConfig{
+		CommonConfig:  config,
+		ReadInterval:  time.Second,
+		WriteInterval: time.Second,
+		TrustDomains:  trustDomains,
+	}
+	c0 := libtalek.NewClient("testClient", clientConfig, leaderRPC)
+	log.Println("Created client")
+	//time.Sleep(time.Duration(rand.Int()%int(clientConfig.WriteInterval)) * time.Nanosecond)
+	//c1 := libtalek.NewClient("c1", clientConfig, leaderRpc)
+	//log.Println("Created c1")
+
+	handle, _ := libtalek.NewTopic()
+	var subscription libtalek.Subscription
+	subscription = handle.Subscription
+
+	read := c0.Poll(&subscription)
+
+	c0.Publish(handle, []byte("PDB Client Trial"))
+	log.Printf("waiting for read.")
+	data := <-read
+
+	log.Printf("Read back: %v\n", data)
+}

--- a/benchmark/server/server.go
+++ b/benchmark/server/server.go
@@ -22,7 +22,7 @@ var configPath = flag.String("config", "../commonconfig.json", "Talek Common Con
 var trustDomainPath = flag.String("trust", "../keys/leaderprivate.json", "Server Configuration")
 var pirSocket = flag.String("socket", "../../pird/pir.socket", "PIR daemon socket")
 
-// Server starts a single, centralized talek server operating with an explicit configuration.
+// Server starts a single, centralized talek server operating with a saved configuration.
 func main() {
 	log.Println("--------------------")
 	log.Println("--- Talek Server ---")
@@ -40,6 +40,9 @@ func main() {
 		log.Printf("Could not parse %s: %v\n", *trustDomainPath, err)
 		return
 	}
+
+	// Default configuration. The server can be started with just a trustdomain
+	// config and this will be used for the serverConfig struct in that case.
 	serverConfig := server.Config{
 		CommonConfig:     config,
 		WriteInterval:    time.Second,
@@ -63,7 +66,7 @@ func main() {
 		usingMock = true
 	}
 
-	s := server.NewCentralized(td.Name, *pirSocket, serverConfig, nil, false)
+	s := server.NewCentralized(td.Name, *pirSocket, serverConfig, nil, serverConfig.TrustDomainIndex == 0)
 	_, port, _ := net.SplitHostPort(td.Address)
 	pnum, _ := strconv.Atoi(port)
 	_ = server.NewNetworkRpc(s, pnum)

--- a/common/follower_interface.go
+++ b/common/follower_interface.go
@@ -1,9 +1,12 @@
 package common
 
+// FollowerInterface dictates the methods used for server-server communication
+// in the Talek system
 type FollowerInterface interface {
 	GetName(args *interface{}, reply *string) error
 	Ping(args *PingArgs, reply *PingReply) error
 	Write(args *WriteArgs, reply *WriteReply) error
+	NextEpoch(args *uint64, reply *interface{}) error
 	BatchRead(args *BatchReadRequest, reply *BatchReadReply) error
 	GetUpdates(args *GetUpdatesArgs, reply *GetUpdatesReply) error
 }

--- a/common/follower_rpc.go
+++ b/common/follower_rpc.go
@@ -77,6 +77,11 @@ func (f *FollowerRpc) Write(args *WriteArgs, reply *WriteReply) error {
 	return err
 }
 
+func (f *FollowerRpc) NextEpoch(args *uint64, reply *interface{}) error {
+	err := f.Call(f.methodPrefix+".NextEpoch", args, reply)
+	return err
+}
+
 func (f *FollowerRpc) BatchRead(args *BatchReadRequest, reply *BatchReadReply) error {
 	//f.log.Printf("BatchRead: enter\n")
 	err := f.Call(f.methodPrefix+".BatchRead", args, reply)

--- a/cuckoo/table_test.go
+++ b/cuckoo/table_test.go
@@ -119,6 +119,18 @@ func TestBasic(t *testing.T) {
 	fmt.Printf("... done \n")
 }
 
+func TestBucket(t *testing.T) {
+	table := NewTable("t", 10, 2, 64, nil, 0)
+	item := &Item{1, GetBytes("value"), 5, 5}
+	ok, _ := table.Insert(item)
+	if !ok {
+		t.Fatalf("Failed to insert item.")
+	}
+	if item.Bucket(table) != 5 {
+		t.Fatalf("Bucket should report expected item position.")
+	}
+}
+
 func TestOutOfBounds(t *testing.T) {
 	table := NewTable("t", 10, 2, 64, nil, 0)
 

--- a/drbg/seed.go
+++ b/drbg/seed.go
@@ -3,7 +3,9 @@ package drbg
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
+
 	"github.com/dchest/siphash"
 )
 
@@ -38,6 +40,23 @@ func (s *Seed) UnmarshalBinary(data []byte) error {
 
 func (s *Seed) MarshalBinary() ([]byte, error) {
 	return s.value[:], nil
+}
+
+// MarshalJSON serializes the seed to JSON
+// Implements the json.Marshaller interface
+func (s *Seed) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.value)
+}
+
+// UnmarshalJSON restores the seed from a JSON representation.
+func (s *Seed) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &s.value); err != nil {
+		return err
+	}
+	if len(s.value) != SeedLength {
+		return errors.New("invlaid drbg seed length")
+	}
+	return nil
 }
 
 func (s *Seed) Key() []byte {

--- a/libtalek/client.go
+++ b/libtalek/client.go
@@ -1,25 +1,24 @@
 package libtalek
 
 import (
-	"github.com/privacylab/talek/common"
-	"github.com/privacylab/talek/drbg"
+	"crypto/rand"
+	"errors"
+	"math/big"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/privacylab/talek/common"
+	"github.com/privacylab/talek/drbg"
 )
 
-/**
- * Client interface for libtalek
- * Goroutines:
- * - 1x RequestManager.writePeriodic
- * - 1x RequestManager.readPeriodic
- */
+// Client represents a connection to the Talek system. Typically created with
+// NewClient, the object manages requests, both reads an writes.
 type Client struct {
 	log    *common.Logger
 	name   string
 	config atomic.Value //ClientConfig
 	dead   int32
-	rand   *drbg.HashDrbg
 	leader common.LeaderInterface
 
 	subscriptions     []Subscription
@@ -30,30 +29,18 @@ type Client struct {
 	lastSeqNo uint64
 }
 
-// The interface for a class that will handle read responses.
-type RequestResponder interface {
-	OnResponse(*common.ReadArgs, *common.ReadReply)
-}
-
 type request struct {
 	*common.ReadArgs
-	RequestResponder
+	*Subscription
 }
 
-//TODO: client needs to know the different trust domain security parameters.
+// NewClient creates a Talek client for reading and writing metadata-protected messages.
 func NewClient(name string, config ClientConfig, leader common.LeaderInterface) *Client {
 	c := &Client{}
 	c.log = common.NewLogger(name)
 	c.name = name
 	c.config.Store(config)
 	c.leader = leader
-
-	rand, err := drbg.NewHashDrbg(nil)
-	if err != nil {
-		c.log.Error.Fatalf("Error creating Hashdrbg: %v\n", err)
-		return nil
-	}
-	c.rand = rand
 
 	//todo: should channel capacity be smarter?
 	c.pendingReads = make(chan request, 5)
@@ -68,37 +55,63 @@ func NewClient(name string, config ClientConfig, leader common.LeaderInterface) 
 
 /** PUBLIC METHODS (threadsafe) **/
 
+// SetConfig allows updating the configuraton of a Client, e.g. if server memebership
+// or speed characteristics for the system are changed.
 func (c *Client) SetConfig(config ClientConfig) {
 	c.config.Store(config)
 }
 
+// Kill stops client processing. This allows for graceful shutdown or suspension of requests.
 func (c *Client) Kill() {
 	atomic.StoreInt32(&c.dead, 1)
 }
 
+// Ping will perform an on-thread ping of the Talek system, allowing the client
+// to validate that it is connected to the Talek system, and check the latency
+// of connection to the server.
 func (c *Client) Ping() bool {
 	var reply common.PingReply
 	err := c.leader.Ping(&common.PingArgs{Msg: "PING"}, &reply)
 	if err == nil && reply.Err == "" {
 		c.log.Info.Printf("Ping success\n")
 		return true
-	} else {
-		c.log.Warn.Printf("Ping fail: err=%v, reply=%v\n", err, reply)
-		return false
 	}
+	c.log.Warn.Printf("Ping fail: err=%v, reply=%v\n", err, reply)
+	return false
 }
 
+// MaxLength returns the maximum allowed message the client can Publish.
+// TODO: support messages spanning multiple data items.
+func (c *Client) MaxLength() int {
+	config := c.config.Load().(ClientConfig)
+	return config.DataSize
+}
+
+// Publish a new message to the end of a topic.
 func (c *Client) Publish(handle *Topic, data []byte) error {
 	config := c.config.Load().(ClientConfig)
-	write_args, err := handle.GeneratePublish(config.CommonConfig, data)
+
+	if len(data) > config.DataSize-PublishingOverhead {
+		return errors.New("message too long")
+	} else if len(data) < config.DataSize-PublishingOverhead {
+		allocation := make([]byte, config.DataSize-PublishingOverhead)
+		copy(allocation[:], data)
+		data = allocation
+	}
+
+	writeArgs, err := handle.GeneratePublish(config.CommonConfig, data)
+	c.log.Info.Printf("Wrote %v(%d) to %d,%d.", writeArgs.Data[0:4], len(writeArgs.Data), writeArgs.Bucket1, writeArgs.Bucket2)
 	if err != nil {
 		return err
 	}
 
-	c.pendingWrites <- write_args
+	c.pendingWrites <- writeArgs
 	return nil
 }
 
+// Poll Subscribes to updates on a given log Subscription.
+// When done reading message,s the the channel can be closed via the Done
+// method.
 func (c *Client) Poll(handle *Subscription) chan []byte {
 	// Check if already subscribed.
 	c.subscriptionMutex.Lock()
@@ -108,12 +121,16 @@ func (c *Client) Poll(handle *Subscription) chan []byte {
 			return nil
 		}
 	}
+	if handle.updates == nil {
+		initSubscription(handle)
+	}
 	c.subscriptions = append(c.subscriptions, *handle)
 	c.subscriptionMutex.Unlock()
 
-	return handle.Updates
+	return handle.updates
 }
 
+// Done unsubscribes a Subscription from being Polled for new items.
 func (c *Client) Done(handle *Subscription) bool {
 	c.subscriptionMutex.Lock()
 	for i := 0; i < len(c.subscriptions); i++ {
@@ -130,7 +147,7 @@ func (c *Client) Done(handle *Subscription) bool {
 
 /** Private methods **/
 func (c *Client) writePeriodic() {
-	var req *common.WriteArgs = nil
+	var req *common.WriteArgs
 
 	for atomic.LoadInt32(&c.dead) == 0 {
 		reply := common.WriteReply{}
@@ -157,18 +174,18 @@ func (c *Client) writePeriodic() {
 }
 
 func (c *Client) readPeriodic() {
-	var request request
+	var req request
 
 	for atomic.LoadInt32(&c.dead) == 0 {
 		reply := common.ReadReply{}
 		conf := c.config.Load().(ClientConfig)
 		select {
-		case request = <-c.pendingReads:
+		case req = <-c.pendingReads:
 			break
 		default:
-			request = c.nextRequest(&conf)
+			req = c.nextRequest(&conf)
 		}
-		encreq, err := request.ReadArgs.Encode(conf.TrustDomains)
+		encreq, err := req.ReadArgs.Encode(conf.TrustDomains)
 		if err != nil {
 			reply.Err = err.Error()
 		} else {
@@ -180,8 +197,8 @@ func (c *Client) readPeriodic() {
 		if reply.GlobalSeqNo.End > c.lastSeqNo {
 			c.lastSeqNo = reply.GlobalSeqNo.End
 		}
-		if request.RequestResponder != nil {
-			request.RequestResponder.OnResponse(request.ReadArgs, &reply)
+		if req.Subscription != nil {
+			req.Subscription.OnResponse(req.ReadArgs, &reply, uint(conf.DataSize))
 		}
 		time.Sleep(conf.ReadInterval)
 	}
@@ -189,10 +206,13 @@ func (c *Client) readPeriodic() {
 
 func (c *Client) generateRandomWrite(config ClientConfig) *common.WriteArgs {
 	args := &common.WriteArgs{}
-	args.Bucket1 = c.rand.RandomUint64() % config.CommonConfig.NumBuckets
-	args.Bucket2 = c.rand.RandomUint64() % config.CommonConfig.NumBuckets
+	var max big.Int
+	b1, _ := rand.Int(rand.Reader, max.SetUint64(config.NumBuckets))
+	b2, _ := rand.Int(rand.Reader, max.SetUint64(config.NumBuckets))
+	args.Bucket1 = b1.Uint64()
+	args.Bucket2 = b2.Uint64()
 	args.Data = make([]byte, config.CommonConfig.DataSize, config.CommonConfig.DataSize)
-	c.rand.FillBytes(args.Data)
+	rand.Read(args.Data)
 	return args
 }
 
@@ -202,7 +222,7 @@ func (c *Client) generateRandomRead(config *ClientConfig) *common.ReadArgs {
 	args.TD = make([]common.PirArgs, len(config.TrustDomains), len(config.TrustDomains))
 	for i := 0; i < len(args.TD); i++ {
 		args.TD[i].RequestVector = make([]byte, vectorSize, vectorSize)
-		c.rand.FillBytes(args.TD[i].RequestVector)
+		rand.Read(args.TD[i].RequestVector)
 		seed, err := drbg.NewSeed()
 		if err != nil {
 			c.log.Error.Fatalf("Error creating random seed: %v\n", err)

--- a/libtalek/client_config.go
+++ b/libtalek/client_config.go
@@ -2,26 +2,28 @@ package libtalek
 
 import (
 	"encoding/json"
-	"github.com/privacylab/talek/common"
 	"io/ioutil"
 	"time"
+
+	"github.com/privacylab/talek/common"
 )
 
+// ClientConfig represents the configuration parameters to Talek needed by
+// the client.
 type ClientConfig struct {
 	*common.CommonConfig `json:"-"`
 
 	// How often should Writes be made to the server
-	WriteInterval time.Duration
+	WriteInterval time.Duration `json:",string"`
 
 	// How often should reads be made to the server
-	ReadInterval time.Duration
+	ReadInterval time.Duration `json:",string"`
 
 	// Where are the different servers?
 	TrustDomains []*common.TrustDomainConfig
 }
 
-// Load configuration from a JSON file. returns the config on success or nil if
-// loading or parsing the file fails.
+// ClientConfigFromFile restores a client configuration from on-disk form.
 func ClientConfigFromFile(file string, commonBase *common.CommonConfig) *ClientConfig {
 	configString, err := ioutil.ReadFile(file)
 	if err != nil {

--- a/libtalek/subscription.go
+++ b/libtalek/subscription.go
@@ -3,6 +3,8 @@ package libtalek
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
+
 	"github.com/agl/ed25519"
 	"github.com/dchest/siphash"
 	"github.com/privacylab/talek/common"
@@ -10,13 +12,18 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
+// Subscription is the readable component of a Talek Log.
+// Subscriptions are created by making a NewTopic, but can be independently
+// shared, and restored from a serialized state. A Subscription is read
+// by calling Client.Poll(subscription) to recieve a channel with new messages
+// read from the Subscription.
 type Subscription struct {
 	// for random looking pir requests
 	drbg *drbg.HashDrbg
 
 	// For learning log positions
-	Seed1 drbg.Seed
-	Seed2 drbg.Seed
+	Seed1 *drbg.Seed
+	Seed2 *drbg.Seed
 
 	// For decrypting messages
 	SharedSecret     *[32]byte
@@ -26,25 +33,30 @@ type Subscription struct {
 	Seqno uint64
 
 	// Notifications of new messages
-	Updates chan []byte
+	updates chan []byte
 }
 
 func NewSubscription() (s *Subscription, err error) {
 	s = &Subscription{}
-	s.Updates = make(chan []byte)
+	err = initSubscription(s)
+	return
+}
+
+func initSubscription(s *Subscription) (err error) {
+	s.updates = make(chan []byte)
 
 	s.drbg, err = drbg.NewHashDrbg(nil)
 	return
 }
 
-func (s *Subscription) generatePoll(config *ClientConfig, seqNo uint64) (*common.ReadArgs, *common.ReadArgs, error) {
+func (s *Subscription) generatePoll(config *ClientConfig, _ uint64) (*common.ReadArgs, *common.ReadArgs, error) {
 	if s.SharedSecret == nil || s.SigningPublicKey == nil {
 		return nil, nil, errors.New("Subscription not fully initialized")
 	}
 
 	args := make([]*common.ReadArgs, 2)
-	seqNoBytes := make([]byte, 12)
-	_ = binary.PutUvarint(seqNoBytes, seqNo)
+	seqNoBytes := make([]byte, 24)
+	_ = binary.PutUvarint(seqNoBytes, s.Seqno)
 
 	num := len(config.TrustDomains)
 
@@ -119,20 +131,31 @@ func (s *Subscription) Decrypt(cyphertext []byte, nonce *[24]byte) ([]byte, erro
 	return plaintext[0:cap(plaintext)], nil
 }
 
-func (s *Subscription) OnResponse(args *common.ReadArgs, reply *common.ReadReply) {
-	msg := s.retrieveResponse(args, reply)
-	if msg != nil && s.Updates != nil {
-		s.Updates <- msg
+func (s *Subscription) OnResponse(args *common.ReadArgs, reply *common.ReadReply, dataSize uint) {
+	msg := s.retrieveResponse(args, reply, dataSize)
+	if msg != nil && s.updates != nil {
+		s.updates <- msg
 	}
 }
 
-// TODO: checksum msgs at topic level so if something random comes back it is filtered out.
-func (s *Subscription) retrieveResponse(args *common.ReadArgs, reply *common.ReadReply) []byte {
+func (s *Subscription) retrieveResponse(args *common.ReadArgs, reply *common.ReadReply, dataSize uint) []byte {
 	data := reply.Data
 
+	// strip out the padding injected by trust domains.
 	for i := 0; i < len(args.TD); i++ {
 		drbg.Overlay(args.TD[i].PadSeed, data)
 	}
 
-	return data
+	var seqNoBytes [24]byte
+	_ = binary.PutUvarint(seqNoBytes[:], s.Seqno)
+
+	// A 'bucket' likely has multiple messages in it. See if any of them are ours.
+	for i := uint(0); i < uint(len(data)); i += dataSize {
+		plaintext, err := s.Decrypt(data[i:i+dataSize], &seqNoBytes)
+		if err == nil {
+			return plaintext
+		}
+		fmt.Printf("decryption failed for read %d of bucket %d [%v](%d): %v\n", i/dataSize, args.Bucket(), data[i:i+4], len(data[i:i+dataSize]), err)
+	}
+	return nil
 }

--- a/libtalek/subscription_test.go
+++ b/libtalek/subscription_test.go
@@ -2,8 +2,9 @@ package libtalek
 
 import (
 	"fmt"
-	"github.com/privacylab/talek/common"
 	"testing"
+
+	"github.com/privacylab/talek/common"
 )
 
 func TestGeneratePoll(t *testing.T) {
@@ -21,7 +22,7 @@ func TestGeneratePoll(t *testing.T) {
 		t.Fatalf("Could generate a poll from an un-configured subscription")
 	}
 
-	topic, err := NewTopic()
+	topic, _ := NewTopic()
 	sub = &topic.Subscription
 	args0, _, err := sub.generatePoll(config, 1)
 	if err != nil {
@@ -80,7 +81,7 @@ func BenchmarkRetrieveResponse(b *testing.B) {
 	// Start timing
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = sub.retrieveResponse(args, reply)
+		_ = sub.retrieveResponse(args, reply, 1024)
 	}
 
 }

--- a/libtalek/topic.go
+++ b/libtalek/topic.go
@@ -3,6 +3,7 @@ package libtalek
 import (
 	"crypto/rand"
 	"encoding/binary"
+
 	"github.com/agl/ed25519"
 	"github.com/dchest/siphash"
 	"github.com/privacylab/talek/bloom"
@@ -11,6 +12,10 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
+// Topic is a writiable Talek log.
+// A topic is created by calling NewTopic().
+// New items are published with a client via client.Publish(&topic, "Msg").
+// Messages can be read from the topic through its contained Subscription.
 type Topic struct {
 
 	// For updates?
@@ -18,11 +23,16 @@ type Topic struct {
 
 	// For authenticity
 	// TODO: this should ratchet.
-	SigningPrivateKey *[64]byte
+	SigningPrivateKey *[64]byte `json:",omitempty"`
 
 	Subscription
 }
 
+// PublishingOverhead represents the number of additional bytes used by encryption and signing.
+const PublishingOverhead = box.Overhead + ed25519.SignatureSize
+
+// NewTopic creates a new Topic, or fails if the system randomness isn't
+// appropriately configured.
 func NewTopic() (t *Topic, err error) {
 	t = &Topic{}
 
@@ -41,9 +51,11 @@ func NewTopic() (t *Topic, err error) {
 	}
 
 	t.Id, _ = binary.Uvarint(id[0:8])
-	t.Subscription.Seed1 = *seed1
-	t.Subscription.Seed2 = *seed2
-	t.Subscription.drbg, err = drbg.NewHashDrbg(nil)
+	t.Subscription.Seed1 = seed1
+	t.Subscription.Seed2 = seed2
+	if err = initSubscription(&t.Subscription); err != nil {
+		return
+	}
 
 	// Create shared secret
 	pub, priv, err := box.GenerateKey(rand.Reader)
@@ -52,6 +64,7 @@ func NewTopic() (t *Topic, err error) {
 	}
 	var sharedKey [32]byte
 	box.Precompute(&sharedKey, pub, priv)
+
 	t.Subscription.SharedSecret = &sharedKey
 
 	// Create signing secrets
@@ -71,7 +84,7 @@ func (t *Topic) GeneratePublish(commonConfig *common.CommonConfig, message []byt
 	k0, k1 = t.Subscription.Seed2.KeyUint128()
 	args.Bucket2 = siphash.Hash(k0, k1, seqNoBytes[:]) % commonConfig.NumBuckets
 
-	t.Subscription.Seqno += 1
+	t.Subscription.Seqno++
 	ciphertext, err := t.encrypt(message, &seqNoBytes)
 	if err != nil {
 		return nil, err
@@ -89,7 +102,6 @@ func (t *Topic) GeneratePublish(commonConfig *common.CommonConfig, message []byt
 	return args, nil
 }
 
-// @TODO: signing. likely via https://github.com/agl/ed25519
 // @TODO: long-term, keys should ratchet, so that messages outside of the
 // active range become refutable. perhaps this could alternatively be done with
 // a server managed primative, with releases of a rachet update as each DB epoch

--- a/libtalek/topic_test.go
+++ b/libtalek/topic_test.go
@@ -3,17 +3,20 @@ package libtalek
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
-	"github.com/privacylab/talek/common"
 	"testing"
+
+	"github.com/privacylab/talek/common"
 )
 
 func TestEncryptDecrypt(t *testing.T) {
 	fmt.Printf("TestEncryptDecrypt:\n")
 	plaintext := "Hello world"
 	var nonce [24]byte
-	copy(nonce[:], []byte("012345678901"))
+	nonceint := uint64(12345678)
+	_ = binary.PutUvarint(nonce[:], nonceint)
 	th, err := NewTopic()
 	if err != nil {
 		t.Fatalf("Error creating topic handle: %v\n", err)
@@ -27,6 +30,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error encrypting plaintext: %v\n", err)
 	}
+	sub.Seqno = nonceint
 	result, err := sub.Decrypt(ciphertext, &nonce)
 	if err != nil {
 		t.Fatalf("Error decrypting ciphertext: %v, %v\n", ciphertext, err)

--- a/server/shard.go
+++ b/server/shard.go
@@ -224,13 +224,20 @@ func (s *Shard) processWrites() {
 			s.sinceFlip++
 
 			// Trigger to swap to next DB.
-			// TODO: time based write interval. likely via a leader-triggered signal.
 			if s.sinceFlip > s.outstandingLimit {
-				s.syncChan <- 1
-				s.sinceFlip = 0
+				s.ApplyWrites()
 			}
 		}
 	}
+}
+
+// ApplyWrites will enque a command to apply any outstanding writes to the
+// database to be seen by subsequent reads.
+// TODO: should take a sequence number to do a better job of consistent
+// interleaving with enqueued reads.
+func (s *Shard) ApplyWrites() {
+	s.syncChan <- 1
+	s.sinceFlip = 0
 }
 
 func (s *Shard) evictOldItems() {

--- a/util/talekcli/main.go
+++ b/util/talekcli/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/privacylab/talek/common"
+	"github.com/privacylab/talek/libtalek"
+)
+
+var config = flag.String("config", "talek.json", "Talek configuration.")
+var create = flag.Bool("create", false, "Create a new Talek log.")
+var share = flag.String("share", "", "Generate a read-only version of a log.")
+var log = flag.String("log", "topic.json", "The Talek log to act upon.")
+var write = flag.String("write", "", "The message to write to the log.")
+var read = flag.Bool("read", false, "Read from an existing talek log.")
+
+// Talekcli provides a minimal command line client interface to talek for
+// writing and reading individual items in the database. This interaction mode
+// is not resistant to traffic analysis attacks, because a single request is
+// made to perform the operations, rather than scheduling them within a
+// consistant stream of requests to mask underlying activity.
+func main() {
+	flag.Parse()
+
+	// Create a new log.
+	if *create {
+		handle, err := libtalek.NewTopic()
+		if err != nil {
+			fmt.Printf("Could not generate new topic: %v\n", err)
+			return
+		}
+		if len(*log) == 0 {
+			fmt.Printf("-create cannot be used without specifying a -log to save to.")
+			return
+		}
+		handleraw, err := json.Marshal(handle)
+		if err != nil {
+			fmt.Printf("Could not flatten log: %v\n", err)
+			return
+		}
+		err = ioutil.WriteFile(*log, handleraw, 0640)
+		if err != nil {
+			fmt.Printf("Failed to write log state: %v\n", err)
+			return
+		}
+		fmt.Printf("New log created at %s\n", *log)
+		return
+	}
+
+	if len(*share) > 0 {
+		dat, readerr := ioutil.ReadFile(*log)
+		if readerr != nil {
+			fmt.Fprintf(os.Stderr, "Could not read %s: %v", *log, readerr)
+			return
+		}
+		var handle libtalek.Topic
+		err := json.Unmarshal(dat, &handle)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not parse %s: %v", *log, err)
+			return
+		}
+		rodat, err := json.Marshal(&handle.Subscription)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not serialize log: %v", err)
+			return
+		}
+		err = ioutil.WriteFile(*share, rodat, 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not write read-only log %s: %v", *share, err)
+		}
+		return
+	}
+
+	var conf libtalek.ClientConfig
+	confraw, err := ioutil.ReadFile(*config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not read config file: %v\n", err)
+		return
+	}
+	err = json.Unmarshal(confraw, &conf)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not parse config file: %v\n", err)
+		return
+	}
+
+	dat, readerr := ioutil.ReadFile(*log)
+	if readerr != nil {
+		fmt.Fprintf(os.Stderr, "Could not read %s: %v", *log, readerr)
+		return
+	}
+	var handle libtalek.Topic
+	err = json.Unmarshal(dat, &handle)
+	if err != nil || handle.SharedSecret == nil {
+		fmt.Fprintf(os.Stderr, "Could not parse log state: %v\n", err)
+		return
+	}
+
+	leaderRPC := common.NewLeaderRpc("RPC", conf.TrustDomains[0])
+	cli := libtalek.NewClient("talekcli", conf, leaderRPC)
+
+	// Read a message.
+	if *read {
+		msgchan := cli.Poll(&handle.Subscription)
+		msg := <-msgchan
+		// print the result.
+		fmt.Printf("%s\n", msg)
+		cli.Done(&handle.Subscription)
+	} else if len(*write) > 0 {
+		if handle.SigningPrivateKey == nil {
+			fmt.Fprintf(os.Stderr, "Cannot write. Only provided read capability for log.")
+			return
+		}
+		cli.Publish(&handle, []byte(*write))
+		time.Sleep(conf.WriteInterval)
+	} else {
+		fmt.Printf("No operation to perform.")
+		return
+	}
+
+	cli.Kill()
+
+	// write updated state back to log.
+	rawstate, err := json.Marshal(&handle)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not serialize updated log: %v\n", err)
+	}
+	err = ioutil.WriteFile(*log, rawstate, 0640)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not update log: %v\n", err)
+	}
+}


### PR DESCRIPTION
Introduce a NextEpoch RPC between leader and followers so leader can explicitly trigger a database flip.

This is gonna be a weird thing to try and get consistent order. I'm not convinced this is the 'correct' way. Instead, there should be a flag in a write that follows the same channel delivery system to signal it. The problem is how followers can identify the special write has been triggered by the leader, and isn't a malicious client RPC. This works as a placehodler until that solution is done.