### PR TITLE
Minimal Command Line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ benchmark/client/client
 benchmark/consistency/consistency
 benchmark/server/server
 pird/pird
+util/talekcli/talekcli
 util/talekutil/talekutil

--- a/drbg/seed.go
+++ b/drbg/seed.go
@@ -3,7 +3,9 @@ package drbg
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
+
 	"github.com/dchest/siphash"
 )
 
@@ -38,6 +40,23 @@ func (s *Seed) UnmarshalBinary(data []byte) error {
 
 func (s *Seed) MarshalBinary() ([]byte, error) {
 	return s.value[:], nil
+}
+
+// MarshalJSON serializes the seed to JSON
+// Implements the json.Marshaller interface
+func (s *Seed) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.value)
+}
+
+// UnmarshalJSON restores the seed from a JSON representation.
+func (s *Seed) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &s.value); err != nil {
+		return err
+	}
+	if len(s.value) != SeedLength {
+		return errors.New("invlaid drbg seed length")
+	}
+	return nil
 }
 
 func (s *Seed) Key() []byte {

--- a/libtalek/client.go
+++ b/libtalek/client.go
@@ -121,10 +121,13 @@ func (c *Client) Poll(handle *Subscription) chan []byte {
 			return nil
 		}
 	}
+	if handle.updates == nil {
+		initSubscription(handle)
+	}
 	c.subscriptions = append(c.subscriptions, *handle)
 	c.subscriptionMutex.Unlock()
 
-	return handle.Updates
+	return handle.updates
 }
 
 // Done unsubscribes a Subscription from being Polled for new items.

--- a/libtalek/client_config.go
+++ b/libtalek/client_config.go
@@ -2,26 +2,28 @@ package libtalek
 
 import (
 	"encoding/json"
-	"github.com/privacylab/talek/common"
 	"io/ioutil"
 	"time"
+
+	"github.com/privacylab/talek/common"
 )
 
+// ClientConfig represents the configuration parameters to Talek needed by
+// the client.
 type ClientConfig struct {
 	*common.CommonConfig `json:"-"`
 
 	// How often should Writes be made to the server
-	WriteInterval time.Duration
+	WriteInterval time.Duration `json:",string"`
 
 	// How often should reads be made to the server
-	ReadInterval time.Duration
+	ReadInterval time.Duration `json:",string"`
 
 	// Where are the different servers?
 	TrustDomains []*common.TrustDomainConfig
 }
 
-// Load configuration from a JSON file. returns the config on success or nil if
-// loading or parsing the file fails.
+// ClientConfigFromFile restores a client configuration from on-disk form.
 func ClientConfigFromFile(file string, commonBase *common.CommonConfig) *ClientConfig {
 	configString, err := ioutil.ReadFile(file)
 	if err != nil {

--- a/libtalek/topic.go
+++ b/libtalek/topic.go
@@ -12,6 +12,10 @@ import (
 	"golang.org/x/crypto/nacl/box"
 )
 
+// Topic is a writiable Talek log.
+// A topic is created by calling NewTopic().
+// New items are published with a client via client.Publish(&topic, "Msg").
+// Messages can be read from the topic through its contained Subscription.
 type Topic struct {
 
 	// For updates?
@@ -19,7 +23,7 @@ type Topic struct {
 
 	// For authenticity
 	// TODO: this should ratchet.
-	SigningPrivateKey *[64]byte
+	SigningPrivateKey *[64]byte `json:",omitempty"`
 
 	Subscription
 }
@@ -27,6 +31,8 @@ type Topic struct {
 // PublishingOverhead represents the number of additional bytes used by encryption and signing.
 const PublishingOverhead = box.Overhead + ed25519.SignatureSize
 
+// NewTopic creates a new Topic, or fails if the system randomness isn't
+// appropriately configured.
 func NewTopic() (t *Topic, err error) {
 	t = &Topic{}
 
@@ -45,8 +51,8 @@ func NewTopic() (t *Topic, err error) {
 	}
 
 	t.Id, _ = binary.Uvarint(id[0:8])
-	t.Subscription.Seed1 = *seed1
-	t.Subscription.Seed2 = *seed2
+	t.Subscription.Seed1 = seed1
+	t.Subscription.Seed2 = seed2
 	if err = initSubscription(&t.Subscription); err != nil {
 		return
 	}

--- a/util/talekcli/main.go
+++ b/util/talekcli/main.go
@@ -129,7 +129,7 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not serialize updated log: %v\n", err)
 	}
-	err = ioutil.WriteFile(*log, rawstate, 0644)
+	err = ioutil.WriteFile(*log, rawstate, 0640)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not update log: %v\n", err)
 	}

--- a/util/talekcli/main.go
+++ b/util/talekcli/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/privacylab/talek/common"
+	"github.com/privacylab/talek/libtalek"
+)
+
+var config = flag.String("config", "talek.json", "Talek configuration.")
+var create = flag.Bool("create", false, "Create a new Talek log.")
+var share = flag.String("share", "", "Generate a read-only version of a log.")
+var log = flag.String("log", "topic.json", "The Talek log to act upon.")
+var write = flag.String("write", "", "The message to write to the log.")
+var read = flag.Bool("read", false, "Read from an existing talek log.")
+
+// Talekcli provides a minimal command line client interface to talek for
+// writing and reading individual items in the database. This interaction mode
+// is not resistant to traffic analysis attacks, because a single request is
+// made to perform the operations, rather than scheduling them within a
+// consistant stream of requests to mask underlying activity.
+func main() {
+	flag.Parse()
+
+	// Create a new log.
+	if *create {
+		handle, err := libtalek.NewTopic()
+		if err != nil {
+			fmt.Printf("Could not generate new topic: %v\n", err)
+			return
+		}
+		if len(*log) == 0 {
+			fmt.Printf("-create cannot be used without specifying a -log to save to.")
+			return
+		}
+		handleraw, err := json.MarshalIndent(handle, "", "  ")
+		if err != nil {
+			fmt.Printf("Could not flatten log: %v\n", err)
+			return
+		}
+		err = ioutil.WriteFile(*log, handleraw, 0640)
+		if err != nil {
+			fmt.Printf("Failed to write log state: %v\n", err)
+			return
+		}
+		fmt.Printf("New log created at %s\n", *log)
+		return
+	}
+
+	if len(*share) > 0 {
+		dat, readerr := ioutil.ReadFile(*log)
+		if readerr != nil {
+			fmt.Fprintf(os.Stderr, "Could not read %s: %v", *log, readerr)
+			return
+		}
+		var handle libtalek.Topic
+		err := json.Unmarshal(dat, &handle)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not parse %s: %v", *log, err)
+			return
+		}
+		rodat, err := json.MarshalIndent(&handle.Subscription, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not serialize log: %v", err)
+			return
+		}
+		err = ioutil.WriteFile(*share, rodat, 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not write read-only log %s: %v", *share, err)
+		}
+		return
+	}
+
+	var conf libtalek.ClientConfig
+	confraw, err := ioutil.ReadFile(*config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not read config file: %v\n", err)
+		return
+	}
+	err = json.Unmarshal(confraw, &conf)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not parse config file: %v\n", err)
+		return
+	}
+
+	dat, readerr := ioutil.ReadFile(*log)
+	if readerr != nil {
+		fmt.Fprintf(os.Stderr, "Could not read %s: %v", *log, readerr)
+		return
+	}
+	var handle libtalek.Topic
+	var subscription libtalek.Subscription
+	err = json.Unmarshal(dat, &handle)
+	if handle.Subscription.SharedSecret == nil {
+		subscription = handle.Subscription
+	} else {
+		err = json.Unmarshal(dat, &subscription)
+	}
+	if err != nil || subscription.SharedSecret == nil {
+		fmt.Fprintf(os.Stderr, "Could not parse log state: %v\n", err)
+		return
+	}
+
+	leaderRPC := common.NewLeaderRpc("RPC", conf.TrustDomains[0])
+	cli := libtalek.NewClient("talekcli", conf, leaderRPC)
+
+	// Read a message.
+	if *read {
+		msgchan := cli.Poll(&subscription)
+		msg := <-msgchan
+		// print the result.
+		fmt.Printf("%s\n", msg)
+		cli.Done(&subscription)
+	} else if len(*write) > 0 {
+		if handle.SigningPrivateKey == nil {
+			fmt.Fprintf(os.Stderr, "Cannot write. Only provided read capability for log.")
+			return
+		}
+		cli.Publish(&handle, []byte(*write))
+		time.Sleep(conf.WriteInterval)
+	} else {
+		fmt.Printf("No operation to perform.")
+		return
+	}
+
+	cli.Kill()
+
+	// write updated state back to log.
+	var rawstate []byte
+	if handle.SigningPrivateKey != nil {
+		handle.Subscription = subscription
+		rawstate, err = json.Marshal(&handle)
+	} else {
+		rawstate, err = json.Marshal(&subscription)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not serialize updated log: %v\n", err)
+	}
+	err = ioutil.WriteFile(*log, rawstate, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not update log: %v\n", err)
+	}
+}


### PR DESCRIPTION
make a talekcli binary for reading and writing logs.

Our config setup remains a bit annoying.
the common config is currently split from the server config / client config / trust domain config.

I think what we eventually ought to do here is have an RPC API on the leaderInterface so that the other parts of talek can learn commonConfig settings from the leader.