### PR TITLE
Coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Binaries
 cli/talekclient/talekclient
 cli/talekfrontead/talekfrontend
 cli/talekreplica/talekreplica
@@ -5,3 +6,7 @@ cli/talekutil/talekutil
 benchmark/consistency/consistency
 benchmark/load/load
 pird/pird
+
+# Coverage
+overalls.coverprofile
+profile.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - make get-tools
 install: true
 script:
-  - make test
+  - make ci
 go:
   - 1.7
   - 1.8

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@
 
 get-tools:
 	go get -u github.com/kardianos/govendor
+	go get github.com/go-playground/overalls
+	go get github.com/mattn/goveralls
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install
 
 test: lint unit
+
+ci: lint coverage
 
 lint:
 	gometalinter --vendor --tests --deadline=60s \
@@ -21,3 +25,7 @@ lint:
 
 unit:
 	govendor test +local
+
+coverage:
+	overalls -project=github.com/privacylab/talek -covermode=count -debug
+	goveralls -coverprofile=overalls.coverprofile -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ $ make get-tools
 All tests should pass before submitting a pull request
 
 ```bash
-$ make lint
 $ make test
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Talek
 [![Build Status](https://travis-ci.org/privacylab/talek.svg?branch=master)](https://travis-ci.org/privacylab/talek)
+[![Coverage Status](https://coveralls.io/repos/github/privacylab/talek/badge.svg?branch=master)](https://coveralls.io/github/privacylab/talek?branch=master)
 [![GoDoc](https://godoc.org/github.com/privacylab/talek?status.svg)](https://godoc.org/github.com/privacylab/talek)
 
 Talek is a privacy-preserving messaging system. User communication is stored on untrusted systems using PIR.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Talek
 [![Build Status](https://travis-ci.org/privacylab/talek.svg?branch=master)](https://travis-ci.org/privacylab/talek)
-[![GoDoc](https://godoc.org/github.com/privacylab/talek?status.svg)](https://godoc.org/github.com/privacylab/talek?status.svg)
+[![GoDoc](https://godoc.org/github.com/privacylab/talek?status.svg)](https://godoc.org/github.com/privacylab/talek)
 
 Talek is a privacy-preserving messaging system. User communication is stored on untrusted systems using PIR.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Talek
 [![Build Status](https://travis-ci.org/privacylab/talek.svg?branch=master)](https://travis-ci.org/privacylab/talek)
+[![GoDoc](https://godoc.org/github.com/privacylab/talek?status.svg)](https://godoc.org/github.com/privacylab/talek?status.svg)
 
 Talek is a privacy-preserving messaging system. User communication is stored on untrusted systems using PIR.
 


### PR DESCRIPTION
- Added a new `make ci` target for having travis upload coverage profiles to coveralls.io.
- Badge added to readme
- Confirmed that coveralls is working with proper source highlighting