### PR TITLE
talekclient: parse read-only share

### DIFF
--- a/cli/talekclient/main.go
+++ b/cli/talekclient/main.go
@@ -56,8 +56,18 @@ func main() {
 		}
 		topic = *nt
 	} else {
-		if err = topic.UnmarshalText(topicdata); err != nil {
-			panic(err)
+		err = topic.UnmarshalText(topicdata)
+		if err != nil {
+			// if it is a read-only share, unmarshal only the Handle part
+			if *read {
+				topic.SigningPrivateKey = new([64]byte)
+				err = topic.Handle.UnmarshalText(topicdata)
+				if err != nil {
+					panic(err)
+				}
+			} else {
+				panic(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
fixes #108

```
$ ./talekclient --config /build/talek/talek_net/talek.json --create
$ ./talekclient --config /build/talek/talek_net/talek.json --share foo
Read-only topic written to foo
$ ./talekclient --verbose --config /build/talek/talek_net/talek.json --topic foo --read
Connection to RPC established.
```
